### PR TITLE
Update for GHC 9.6-9.12 and modernize build configuration

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,7 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.17.20230811
-#
-# REGENDATA ("0.17.20230811",["github","stable-heap.cabal"])
+# version: 0.19 (manual)
 #
 name: Haskell-CI
 on:
@@ -19,246 +17,107 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
-    timeout-minutes:
-      60
-    container:
-      image: buildpack-deps:bionic
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.1
+          - compiler: ghc-9.12.2
             compilerKind: ghc
-            compilerVersion: 9.6.1
-            setup-method: ghcup
+            compilerVersion: 9.12.2
             allow-failure: false
-          - compiler: ghc-9.4.4
+          - compiler: ghc-9.10.3
             compilerKind: ghc
-            compilerVersion: 9.4.4
-            setup-method: ghcup
+            compilerVersion: 9.10.3
             allow-failure: false
-          - compiler: ghc-9.2.7
+          - compiler: ghc-9.8.4
             compilerKind: ghc
-            compilerVersion: 9.2.7
-            setup-method: ghcup
+            compilerVersion: 9.8.4
             allow-failure: false
-          - compiler: ghc-9.0.2
+          - compiler: ghc-9.6.7
             compilerKind: ghc
-            compilerVersion: 9.0.2
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-8.10.7
-            compilerKind: ghc
-            compilerVersion: 8.10.7
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-8.8.4
-            compilerKind: ghc
-            compilerVersion: 8.8.4
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.6.5
-            compilerKind: ghc
-            compilerVersion: 8.6.5
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.4.4
-            compilerKind: ghc
-            compilerVersion: 8.4.4
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.2.2
-            compilerKind: ghc
-            compilerVersion: 8.2.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.0.2
-            compilerKind: ghc
-            compilerVersion: 8.0.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.10.3
-            compilerKind: ghc
-            compilerVersion: 7.10.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.8.4
-            compilerKind: ghc
-            compilerVersion: 7.8.4
-            setup-method: hvr-ppa
+            compilerVersion: 9.6.7
             allow-failure: false
       fail-fast: false
     steps:
-      - name: apt
+      - name: Set up GHC ${{ matrix.compilerVersion }}
+        uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          ghc-version: ${{ matrix.compilerVersion }}
+          cabal-version: latest
+
+      - name: Set environment variables
         run: |
-          apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          else
-            apt-add-repository -y 'ppa:hvr/ghc'
-            apt-get update
-            apt-get install -y "$HCNAME"
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          fi
-        env:
-          HCKIND: ${{ matrix.compilerKind }}
-          HCNAME: ${{ matrix.compiler }}
-          HCVER: ${{ matrix.compilerVersion }}
-      - name: Set PATH and environment variables
-        run: |
-          echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-          echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
-          HCDIR=/opt/$HCKIND/$HCVER
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-            HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-            HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          else
-            HC=$HCDIR/bin/$HCKIND
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          fi
 
-          HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
-          echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
-          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
-          echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
-          echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
-          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
-        env:
-          HCKIND: ${{ matrix.compilerKind }}
-          HCNAME: ${{ matrix.compiler }}
-          HCVER: ${{ matrix.compilerVersion }}
-      - name: env
-        run: |
-          env
-      - name: write cabal config
-        run: |
-          mkdir -p $CABAL_DIR
-          cat >> $CABAL_CONFIG <<EOF
-          remote-build-reporting: anonymous
-          write-ghc-environment-files: never
-          remote-repo-cache: $CABAL_DIR/packages
-          logs-dir:          $CABAL_DIR/logs
-          world-file:        $CABAL_DIR/world
-          extra-prog-path:   $CABAL_DIR/bin
-          symlink-bindir:    $CABAL_DIR/bin
-          installdir:        $CABAL_DIR/bin
-          build-summary:     $CABAL_DIR/logs/build.log
-          store-dir:         $CABAL_DIR/store
-          install-dirs user
-            prefix: $CABAL_DIR
-          repository hackage.haskell.org
-            url: http://hackage.haskell.org/
-          EOF
-          cat >> $CABAL_CONFIG <<EOF
-          program-default-options
-            ghc-options: $GHCJOBS +RTS -M3G -RTS
-          EOF
-          cat $CABAL_CONFIG
-      - name: versions
-        run: |
-          $HC --version || true
-          $HC --print-project-git-commit-id || true
-          $CABAL --version || true
-      - name: update cabal index
-        run: |
-          $CABAL v2-update -v
-      - name: install cabal-plan
-        run: |
-          mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.7.3.0/cabal-plan-0.7.3.0-x86_64-linux.xz > cabal-plan.xz
-          echo 'f62ccb2971567a5f638f2005ad3173dba14693a45154c1508645c52289714cb2  cabal-plan.xz' | sha256sum -c -
-          xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
-          rm -f cabal-plan.xz
-          chmod a+x $HOME/.cabal/bin/cabal-plan
-          cabal-plan --version
-      - name: checkout
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           path: source
-      - name: initial cabal.project for sdist
+
+      - name: Restore cache
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store
+          restore-keys: ${{ runner.os }}-${{ matrix.compiler }}-
+
+      - name: Update cabal index
+        run: cabal update
+
+      - name: Initial cabal.project for sdist
         run: |
           touch cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/." >> cabal.project
           cat cabal.project
-      - name: sdist
+
+      - name: Create sdist
         run: |
           mkdir -p sdist
-          $CABAL sdist all --output-dir $GITHUB_WORKSPACE/sdist
-      - name: unpack
+          cabal sdist all --output-dir $GITHUB_WORKSPACE/sdist
+
+      - name: Unpack sdist
         run: |
           mkdir -p unpacked
           find sdist -maxdepth 1 -type f -name '*.tar.gz' -exec tar -C $GITHUB_WORKSPACE/unpacked -xzvf {} \;
-      - name: generate cabal.project
+
+      - name: Generate cabal.project
         run: |
           PKGDIR_stable_heap="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/stable-heap-[0-9.]*')"
           echo "PKGDIR_stable_heap=${PKGDIR_stable_heap}" >> "$GITHUB_ENV"
           rm -f cabal.project cabal.project.local
           touch cabal.project
-          touch cabal.project.local
           echo "packages: ${PKGDIR_stable_heap}" >> cabal.project
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package stable-heap" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
-          cat >> cabal.project <<EOF
-          EOF
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(stable-heap)$/; }' >> cabal.project.local
+          echo "package stable-heap" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat cabal.project
-          cat cabal.project.local
-      - name: dump install plan
+
+      - name: Build dependencies
         run: |
-          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
-          cabal-plan
-      - name: restore cache
-        uses: actions/cache/restore@v3
-        with:
-          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
-          path: ~/.cabal/store
-          restore-keys: ${{ runner.os }}-${{ matrix.compiler }}-
-      - name: install dependencies
+          cabal build --enable-tests --enable-benchmarks --dependencies-only -j2 all
+
+      - name: Build
         run: |
-          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only -j2 all
-          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dependencies-only -j2 all
-      - name: build w/o tests
+          cabal build --enable-tests --enable-benchmarks all
+
+      - name: Run tests
         run: |
-          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
-      - name: build
+          cabal test --enable-tests all --test-show-details=direct
+
+      - name: Check
         run: |
-          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
-      - name: tests
+          cd ${PKGDIR_stable_heap}
+          cabal check
+
+      - name: Haddock
         run: |
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
-      - name: cabal check
-        run: |
-          cd ${PKGDIR_stable_heap} || false
-          ${CABAL} -vnormal check
-      - name: haddock
-        run: |
-          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
-      - name: unconstrained build
-        run: |
-          rm -f cabal.project.local
-          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
-      - name: save cache
-        uses: actions/cache/save@v3
+          cabal haddock --enable-tests --enable-benchmarks all
+
+      - name: Save cache
+        uses: actions/cache/save@v4
         if: always()
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}

--- a/stable-heap.cabal
+++ b/stable-heap.cabal
@@ -1,3 +1,4 @@
+cabal-version:       2.2
 name:                stable-heap
 version:             0.2.1.0
 synopsis:            Purely functional stable heaps (fair priority queues)
@@ -20,24 +21,15 @@ homepage:            https://github.com/jmcarthur/stable-heap
 bug-reports:         https://github.com/jmcarthur/stable-heap/issues
 category:            Data Structures
 build-type:          Simple
-cabal-version:       >=1.10
 stability:           experimental
-tested-with:         GHC ==7.8.4,
-                     GHC ==7.10.3,
-                     GHC ==8.0.2,
-                     GHC ==8.2.2,
-                     GHC ==8.4.4,
-                     GHC ==8.6.5,
-                     GHC ==8.8.4,
-                     GHC ==8.10.7,
-                     GHC ==9.0.2,
-                     GHC ==9.2.7,
-                     GHC ==9.4.4,
-                     GHC ==9.6.1
+tested-with:         GHC ==9.6.7,
+                     GHC ==9.8.4,
+                     GHC ==9.10.3,
+                     GHC ==9.12.2
 
 library
   exposed-modules:     Data.Heap.Stable
-  build-depends:       base >=4.7 && <4.19
+  build-depends:       base ^>=4.18 || ^>=4.19 || ^>=4.20 || ^>=4.21
   hs-source-dirs:      src
   default-language:    Haskell2010
   other-extensions:    DeriveTraversable, Trustworthy, TypeFamilies
@@ -46,25 +38,25 @@ test-suite test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   build-depends:       base,
-                       QuickCheck,
+                       QuickCheck ^>=2.16,
                        stable-heap,
-                       tasty,
-                       tasty-quickcheck,
-                       transformers
+                       tasty ^>=1.5,
+                       tasty-quickcheck ^>=0.11,
+                       transformers ^>=0.6
   main-is:             Test.hs
   default-language:    Haskell2010
 
 benchmark bench
   type:                exitcode-stdio-1.0
   hs-source-dirs:      bench
-  build-depends:       base >=4.7 && <4.19,
-                       criterion >= 1.1,
-                       fingertree >= 0.1,
-                       heaps >= 0.3,
-                       mwc-random >= 0.13,
-                       pqueue >= 1.2,
+  build-depends:       base,
+                       criterion ^>=1.6,
+                       fingertree ^>=0.1,
+                       heaps ^>=0.4,
+                       mwc-random ^>=0.15,
+                       pqueue ^>=1.6,
                        stable-heap,
-                       vector >= 0.10
+                       vector ^>=0.13
   main-is:             Bench.hs
   default-language:    Haskell2010
 

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -37,7 +37,7 @@ tests =
     \(H a :: H Int Int) (H b) ->
       Heap.toList (Heap.append a b) == Heap.toList a ++ Heap.toList b
   , testProperty "appends" $
-    \(map toHeap -> hs :: [Heap Int Int]) ->
+    \(map toHeap -> (hs :: [Heap Int Int])) ->
       (Heap.toList . Heap.appends) hs == concatMap Heap.toList hs
   , testProperty "minView" $
     \(H h :: H Int Int) ->
@@ -103,7 +103,7 @@ tests =
     \(H (fmap apply -> a) :: H [Int] (Fun Int Int)) (H b :: H [Int] Int) ->
       Heap.toList (a <*> b) == fromWriterT (toWriterT a <*> toWriterT b)
   , testProperty "(>>=)" $
-    \(H a :: H [Int] Int) (fmap toHeap . apply -> f :: Int -> Heap [Int] Int) ->
+    \(H a :: H [Int] Int) (fmap toHeap . apply -> (f :: Int -> Heap [Int] Int)) ->
       Heap.toList (a >>= f) == fromWriterT (toWriterT a >>= toWriterT . f)
   ]
 


### PR DESCRIPTION
## Summary
- Bump base constraint to support GHC 9.6 through 9.12
- Update tested-with to GHC 9.6.7, 9.8.4, 9.10.3, 9.12.2
- Switch to cabal-version 2.2 and use ^>= syntax for dependencies
- Update test/benchmark dependencies to recent versions
- Fix view pattern syntax for GHC 9.12 compatibility
- Simplify CI workflow using haskell-actions/setup@v2

## Test plan
- [ ] CI passes on all four GHC versions